### PR TITLE
Corrected example code in README, modified regex for markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,6 @@ You can find an example of what a compatible file should look like in ```example
 
 Then, run
 
-	python miniref-py -f path/to/your/textfile.txt
+	python miniref.py -f path/to/your/textfile.txt
 
 Afterwards, your references in ``textfile.txt`` should be numbered neatly.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 miniref.py is a small utility to make sorting out references in lengthy e-mails just a bit less cumbersome.
 
 # make it work
-Write what you need to say into a text file. Mark each reference with ``[x]`` in the text and put whatever you want to refer to at the end of your e-mail, after the signature, in this format:
+Write what you need to say into a text file. Mark each reference with ``[^x]`` in the text and put whatever you want to refer to at the end of your e-mail, after the signature, in this format:
 
 	[^x] http://zombietetris.de. The reference
 	    may span across several lines.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Write what you need to say into a text file. Mark each reference with ``[^x]`` i
 	[^x] http://zombietetris.de. The reference
 	    may span across several lines.
 
-``x`` can be any alphanumerical character or special character except for ``[`` or ``]``.
+``x`` can be any single alphanumerical character or special character except for ``[`` or ``]``.
 
 The current supported signatures are:
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ Write what you need to say into a text file. Mark each reference with ``[^x]`` i
 	[^x] http://zombietetris.de. The reference
 	    may span across several lines.
 
-``x`` can be any single alphanumerical character or special character except for ``[`` or ``]``.
+``x`` can be one or more alphanumerical characters or special characters except for ``[`` or ``]``.
+
 
 The current supported signatures are:
 

--- a/miniref.py
+++ b/miniref.py
@@ -73,7 +73,7 @@ def number_references(file_str):
             print("setting up bibliography...", file=sys.stderr)
 
         # TODO: make this work for digits >9 as well
-        markers = re.findall("(\[\^[^\[\]]\])", line)
+        markers = re.findall("(\[\^[^\[\]]+\])", line)
 
         # still sifting though text, substitute placeholder markers with proper ones
         if (not is_bibliography):

--- a/miniref.py
+++ b/miniref.py
@@ -72,7 +72,6 @@ def number_references(file_str):
             is_bibliography = True
             print("setting up bibliography...", file=sys.stderr)
 
-        # TODO: make this work for digits >9 as well
         markers = re.findall("(\[\^[^\[\]]+\])", line)
 
         # still sifting though text, substitute placeholder markers with proper ones


### PR DESCRIPTION
Now supports markers consisting of multiple characters -- which, incidentally, fixed support for umlauts and even some simple (ascii) special characters for me (I said Unicode in my commit message, though UTF-8 might have been more correct...). I could previously not use e.g. French accents or the tilde.

Also corrected example code provided in README.