### PR TITLE
move the shebang line before the license header

### DIFF
--- a/miniref.py
+++ b/miniref.py
@@ -1,3 +1,5 @@
+#! /usr/bin/env python
+
 '''
 The MIT License (MIT)
 
@@ -21,8 +23,6 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 '''
-
-#! /usr/bin/env python
 
 from __future__ import print_function
 from tempfile import mkstemp


### PR DESCRIPTION
The Shebang line must be the first line in a script - otherwise executing with `./miniref.py` tries to interpret the license header as shell commands.
